### PR TITLE
Modernize stdlib usage via go fix analyzers

### DIFF
--- a/examples/direct/ping.go
+++ b/examples/direct/ping.go
@@ -61,7 +61,7 @@ var PingComponent = &component.Descriptor{
 
 		return nil
 	},
-	OptionsType: reflect.TypeOf(PingOptions{}),
+	OptionsType: reflect.TypeFor[PingOptions](),
 	Aspects:     nil,
 	Interests:   nil,
 }

--- a/examples/embed/ping.go
+++ b/examples/embed/ping.go
@@ -63,7 +63,7 @@ var PingComponent = &component.Descriptor{
 
 		return nil
 	},
-	OptionsType: reflect.TypeOf(PingOptions{}),
+	OptionsType: reflect.TypeFor[PingOptions](),
 	Aspects:     []string{PingTarget},
 	Interests:   nil,
 }

--- a/examples/embed/probe.go
+++ b/examples/embed/probe.go
@@ -51,7 +51,7 @@ var ProbeComponent = &component.Descriptor{
 
 		return nil
 	},
-	OptionsType: reflect.TypeOf(ProbeOptions{}),
+	OptionsType: reflect.TypeFor[ProbeOptions](),
 	Aspects:     nil,
 	Interests:   []string{PongTarget},
 }

--- a/extractdoc.go
+++ b/extractdoc.go
@@ -99,7 +99,7 @@ func ExtractDoc(content, name string) (string, error) {
 	if f.Doc == nil {
 		return "", fmt.Errorf("the Go source file has no package doc comment")
 	}
-	for _, section := range strings.Split(f.Doc.Text(), "\n# ") {
+	for section := range strings.SplitSeq(f.Doc.Text(), "\n# ") {
 		if body := strings.TrimPrefix(section, "Service "+name); body != section &&
 			body != "" &&
 			body[0] == '\r' || body[0] == '\n' {

--- a/healthprobe/grpc.go
+++ b/healthprobe/grpc.go
@@ -55,9 +55,7 @@ func StartGRPC(l *component.L, lis net.Listener, monitor Monitor) {
 	// signal via the abort channel, which initiates an immediate stop regardless of
 	// context state. This approach ensures that the server can adapt to various
 	// stopping scenarios effectively, ensuring resources are released appropriately.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		select {
 		case <-l.Stopping():
 			s.GracefulStop()
@@ -66,7 +64,7 @@ func StartGRPC(l *component.L, lis net.Listener, monitor Monitor) {
 		case <-abort:
 			s.Stop()
 		}
-	}()
+	})
 
 	// We must stack the listen and serve, to ensure we clean this resource.
 	wg.Add(1)

--- a/healthprobe/http.go
+++ b/healthprobe/http.go
@@ -64,9 +64,7 @@ func StartHTTP(l *component.L, address string, monitor Monitor) {
 	// regardless of context state. This approach ensures that the server can adapt
 	// to various shutdown scenarios effectively, ensuring resources are released
 	// appropriately.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		select {
 		case <-l.Stopping():
 			if err := s.Shutdown(l.Context()); err != nil {
@@ -82,7 +80,7 @@ func StartHTTP(l *component.L, address string, monitor Monitor) {
 				slog.Error("shutdown http server", "error", err)
 			}
 		}
-	}()
+	})
 
 	// We must stack the listen and serve, to ensure we clean this resource.
 	wg.Add(1)

--- a/kafkalinker/kafkaflags.go
+++ b/kafkalinker/kafkaflags.go
@@ -103,7 +103,7 @@ func (f *ConfigFlag) findFieldByName(key string) (field reflect.Value, ok bool) 
 	value := reflect.ValueOf(f).Elem() // Start with the ConfigFlag underlying value.
 
 	for _, name := range strings.Split(key, ".") {
-		if value.Kind() == reflect.Ptr {
+		if value.Kind() == reflect.Pointer {
 			if value.IsNil() {
 				// Can't dereference empty pointer, returning empty field.
 				return reflect.Value{}, false

--- a/kafkalinker/kafkaflags.go
+++ b/kafkalinker/kafkaflags.go
@@ -102,7 +102,7 @@ func (f *ConfigFlag) Set(s string) error {
 func (f *ConfigFlag) findFieldByName(key string) (field reflect.Value, ok bool) {
 	value := reflect.ValueOf(f).Elem() // Start with the ConfigFlag underlying value.
 
-	for _, name := range strings.Split(key, ".") {
+	for name := range strings.SplitSeq(key, ".") {
 		if value.Kind() == reflect.Pointer {
 			if value.IsNil() {
 				// Can't dereference empty pointer, returning empty field.

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -73,12 +73,12 @@ func TestL_Run(t *testing.T) {
 		const goroutines = 16
 		RunProc(func(l *L) {
 			done := make(chan struct{})
-			for i := 0; i < goroutines; i++ {
+			for i := range goroutines {
 				l.Go("child#"+strconv.Itoa(i), func(l *L) {
 					done <- struct{}{}
 				})
 			}
-			for i := 0; i < goroutines; i++ {
+			for range goroutines {
 				select {
 				case <-done:
 				case <-time.After(SyncTimeout):
@@ -111,7 +111,7 @@ func TestL_Cleanup(t *testing.T) {
 		const count = 100
 		order := make(map[int]int) // map: cleanupFn#index -> called order
 		RunProc(func(l *L) {
-			for i := 0; i < count; i++ {
+			for i := range count {
 				index := i
 				l.Cleanup(func() {
 					order[index] = len(order)
@@ -197,7 +197,7 @@ func TestL_Fatal(t *testing.T) {
 			t.Run(fmt.Sprintf("ConcurrentCalls=%d", goroutines), func(t *testing.T) {
 				RunProc(func(l *L) {
 					done := make(chan struct{})
-					for i := 0; i < goroutines; i++ {
+					for i := range goroutines {
 						go func(index int) {
 							defer func() { done <- struct{}{} }()
 							l.Fatal(fmt.Errorf("test error from goroutine #%d", index))
@@ -207,7 +207,7 @@ func TestL_Fatal(t *testing.T) {
 					// pay attention to the fact that we're still in the primary goroutine
 					// of the lifecycle - calls to L.Fatal from other goroutines do not
 					// (and cannot) affect the primary goroutine.
-					for i := 0; i < goroutines; i++ {
+					for range goroutines {
 						select {
 						case <-done:
 						case <-time.After(SyncTimeout):

--- a/loader/entrypoint.go
+++ b/loader/entrypoint.go
@@ -71,7 +71,7 @@ func (m signalMiddleware) hardStop(l *component.L) {
 	signal.Notify(sig, os.Interrupt)
 	defer signal.Stop(sig)
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case <-sig:
 		case <-l.Done():

--- a/loader/example_test.go
+++ b/loader/example_test.go
@@ -137,7 +137,7 @@ var SourceComponent = &component.Descriptor{
 	// some loaders use the options-type to during construction of footprints from
 	// text to unmarshal the appropriate options for each component. the loader
 	// package does not use this field.
-	OptionsType: reflect.TypeOf(SourceOptions{}),
+	OptionsType: reflect.TypeFor[SourceOptions](),
 	// a component declares the aspects it will publish. at this time, this field is
 	// not used by the loader package and provides for expressiveness.
 	Aspects: []string{Linkage},

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"runtime/pprof"
 	gotrace "runtime/trace"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -276,12 +277,7 @@ func (f *forkGroup) Wait(ctx context.Context) (ready int) {
 }
 
 func IsEnabled(d *component.Descriptor) bool {
-	for i := range Descriptors {
-		if d == Descriptors[i] {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(Descriptors, d)
 }
 
 type Footprint struct {

--- a/loader/loaderflags/enabled.go
+++ b/loader/loaderflags/enabled.go
@@ -87,7 +87,7 @@ func triStateFlag(fs *flag.FlagSet, name string) *triState {
 	return f
 }
 
-func (f *triState) Get() interface{} {
+func (f *triState) Get() any {
 	return *f == triStateTrue
 }
 


### PR DESCRIPTION
Sweeps the module with go fix so the source uses the forms the toolchain itself considers preferred (any over interface{}, reflect.TypeFor, integer ranges, strings.SplitSeq, WaitGroup.Go, and so on), keeping reviews focused on substance rather than style drift.

Seven analyzers produced diffs and each landed as its own commit so the log records which analyzer made each change. Others either matched nothing or are gated on a newer go directive than the module pins (newexpr, for example, needs Go 1.26 while the module is at 1.24); a final default-set go fix ./... was a no-op. The change is mechanical: every commit was verified with go build and a test compile.

The deprecation tracks in #10, #11, #12, #13, and #14 are out of scope.