### PR TITLE
Detach lifecycle span from L.Context()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,195 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is a Go library providing types and functions for building enterprise message-driven component systems. Components are deployable units that observe and react to events, with **Aspects** (what they publish) and **Interests** (what they subscribe to) linked via a pub/sub system.
+
+## Commands
+
+### Testing
+```bash
+# Run all tests
+go test ./...
+
+# Run tests with verbose output
+go test -v ./...
+
+# Run a specific test
+go test -run TestName ./...
+
+# Run tests in a specific package
+go test ./loader/...
+
+# Run tests with race detector
+go test -race ./...
+```
+
+### Building
+```bash
+# Build the module
+go build ./...
+
+# Build an example
+go build ./examples/direct
+go build ./examples/embed
+
+# Run an example
+go run ./examples/direct
+```
+
+### Linting & Formatting
+```bash
+# Format code
+go fmt ./...
+
+# Run go vet
+go vet ./...
+
+# Run staticcheck (if installed)
+staticcheck ./...
+```
+
+### Module Management
+```bash
+# Tidy dependencies
+go mod tidy
+
+# Verify dependencies
+go mod verify
+
+# Download dependencies
+go mod download
+```
+
+## Architecture
+
+### Core Concepts
+
+**Component Lifecycle (`lifecycle.go`, `procedure.go`)**
+- **L (Lifecycle)**: Manages concurrent execution, logging, cleanup, and graceful shutdown
+  - `L.Context()`: Main context, cancelled on termination
+  - `L.GraceContext()`: Cancelled when stopping gracefully (before Context)
+  - `L.Stopping()`: Channel closed when graceful stop begins
+  - `L.Continue()`: Helper to check if lifecycle should continue
+  - `L.Go(name, proc)` / `L.Fork(name, procedure)`: Spawn child lifecycles
+  - `L.Cleanup()` / `L.CleanupError()`: Register LIFO cleanup functions
+  - `L.Fatal(err)`: Terminate lifecycle with error (only call from main goroutine)
+  - `L.Stop(timeout)`: Request graceful shutdown
+- **Procedure**: Interface with `Exec(*L)` method for lifecycle body
+- **Proc / ProcE**: Function adapters for Procedure interface
+- **Run(procedure, opts...)**: Entry point to execute a lifecycle
+
+**Component Descriptor (`descriptor.go`)**
+- Describes a component's identity, flags, bootstrap logic, and pub/sub topology
+- **Aspects**: Topics the component publishes to
+- **Interests**: Topics the component subscribes from
+- **Linker**: Interface to resolve aspects/interests to pub/sub targets (Topics/Subscriptions)
+- **Bootstrap function**: `func(l *L, target Linker, options any) error`
+
+**Loader System (`loader/`)**
+- **Footprint**: Describes deployment topology with Allocations (component instances)
+- **Claim**: Resource allocation for a single component instance
+  - Links Component descriptor + Options + Linker binding
+  - Provides `Ready()` channel signaling successful bootstrap
+- **Load(footprint, opts...)**: Main entry point to initialize and run components
+- **Linkers** (`loader/linkers.go`):
+  - `SharedMemLinker`: In-memory pub/sub for single-process testing
+  - `MuxLinker`: Multi-scheme support (kafka://, mem://, etc.)
+
+### Package Structure
+
+- **Root package** (`component`): Core lifecycle, procedure, descriptor types
+- **`loader/`**: Component loading, footprints, claims, linkers, flag parsing
+  - **`loaderflags/`**: Flag parsing utilities (enabled, required, help)
+- **`fileloader/`**: Load configurations from JSON/YAML files
+- **`kafkalinker/`**: Kafka-specific linker implementation
+- **`kafkaloader/`**: Kafka topic/subscription builders
+- **`healthprobe/`**: HTTP/gRPC health check servers
+- **`examples/`**: Demo applications showing usage patterns
+  - `direct/`: Manual footprint construction
+  - `embed/`: Embedded component pattern
+
+### Key Patterns
+
+**Lifecycle Management**
+- Lifecycles are hierarchical: child lifecycles inherit parent context and stopping signal
+- Use `L.Fork()` to create child lifecycles that run concurrently
+- Cleanup functions run in LIFO order, even if lifecycle terminates abruptly
+- `L.Fatal()` terminates the current lifecycle via `runtime.Goexit()` - only call from the main lifecycle goroutine
+
+**Graceful Shutdown**
+```go
+for l.Continue() {
+    // work loop
+}
+// or
+select {
+case <-l.Stopping():
+    // graceful stop
+case <-l.Context().Done():
+    // forced termination
+}
+```
+
+**Component Linking**
+- Aspects and Interests must be declared in Descriptor
+- Linker resolves them to concrete pub/sub Topics/Subscriptions
+- Use `SharedMemLinker` for in-process testing, Kafka linkers for production
+
+**Tracing Contract**
+- `l.Context()` is detached from the lifecycle span: spans started from it are roots of independent traces. This is what subscription handlers and other per-iteration work should use, so trace size is bounded per invocation rather than by component uptime.
+- `l.Span()` is the lifecycle span. It opens at lifecycle start, closes at lifecycle completion, and is intended for lifecycle-scope observability (attributes, events, errors). `L.Error` and `L.Fatal` record onto it automatically.
+- Per-handler instrumentation should link back to the lifecycle for backend navigability: `trace.WithLinks(trace.Link{SpanContext: l.Span().SpanContext()})`.
+- One-shot work that genuinely belongs under the lifecycle span (e.g., loader bootstrap stages) opts into nesting by attaching the span explicitly: `trace.ContextWithSpan(l.Context(), l.Span())`.
+- See package doc and `examples/direct/pong.go` for the canonical handler shape.
+
+**Testing**
+- Tests use table-driven patterns with subtests
+- `SyncTimeout` constant (1 second) for synchronization events
+- Use `L.Stop(timeout)` to cleanly terminate test lifecycles
+
+## Common Workflows
+
+### Adding a New Component
+1. Define a `component.Descriptor` with Name, Doc, Aspects, Interests
+2. Implement Bootstrap function: `func(l *L, linker Linker, options any) error`
+3. Register component in `loader.Descriptors` if using loader package
+4. Link aspects via `linker.LinkAspect(ctx, aspect)` → `*pubsub.Topic`
+5. Link interests via `linker.LinkInterest(ctx, interest)` → `*pubsub.Subscription`
+
+### Running Tests for a Component
+```bash
+# Test the component package
+go test -v -run TestComponentName ./path/to/package
+```
+
+### Debugging with Profiling
+```bash
+# Run with CPU profile
+go run ./examples/direct -cpuprofile=cpu.prof
+
+# Run with memory profile
+go run ./examples/direct -memprofile=mem.prof
+
+# Run with trace
+go run ./examples/direct -trace=trace.out
+```
+
+## Module Information
+
+- **Module**: `github.com/danielorbach/go-component`
+- **Go Version**: 1.24.0
+- **Key Dependencies**:
+  - `gocloud.dev/pubsub`: Portable pub/sub abstraction
+  - `github.com/IBM/sarama`: Kafka client
+  - `go.opentelemetry.io/otel`: OpenTelemetry tracing
+  - `github.com/peterbourgon/ff/v3`: Flag parsing
+
+## Notes
+
+- This library uses OpenTelemetry for distributed tracing (see `tracer` variables)
+- Pprof labels are applied to goroutines for better profiling (`component.name`, `component.depth`)
+- Health probes track lifecycle states (started/completed) via hooks
+- The loader enforces single-load semantics (Load() can only be called once)

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,53 @@
+// Package component provides types and functions for building enterprise
+// message-driven component systems. Components are deployable units that
+// observe and react to events. They are described by a [Descriptor] (identity,
+// flags, bootstrap logic, pub/sub topology) and run inside an [L] (lifecycle)
+// that manages concurrent execution, logging, cleanup, and graceful shutdown.
+//
+// # Tracing contract
+//
+// The framework distinguishes two scopes of OpenTelemetry observability:
+//
+//   - The lifecycle scope. Each lifecycle owns one span — accessible via
+//     [L.Span] — that opens when the lifecycle starts and closes when it
+//     completes. Lifecycle spans nest: a child lifecycle's span is a child of
+//     its parent's. Use the lifecycle span to record attributes, events, and
+//     errors that pertain to the lifecycle event itself (started, completed,
+//     bootstrap status). [L.Error] and [L.Fatal] do this automatically.
+//
+//   - The handler scope. Spans started from [L.Context] are roots of
+//     independent traces, intentionally detached from the lifecycle span.
+//     This is the framework's mitigation against unbounded traces: a
+//     subscription consumer that handles thousands of messages over hours of
+//     uptime would, if its handler spans inherited the lifecycle span as
+//     parent, accumulate spans into a single trace whose size grows with
+//     uptime and saturates downstream backends. By severing this parent
+//     relationship at l.Context(), each handler invocation produces its own
+//     bounded trace.
+//
+// Per-handler instrumentation should link back to the lifecycle for
+// navigation in the trace backend:
+//
+//	ctx, span := tracer.Start(l.Context(), "consume",
+//		trace.WithSpanKind(trace.SpanKindConsumer),
+//		trace.WithLinks(trace.Link{SpanContext: l.Span().SpanContext()}),
+//	)
+//	defer span.End()
+//
+// Authors integrating a new transport (e.g., a non-Kafka subscription
+// consumer) should follow the same shape: l.Context() for the handler's
+// parent context, a link back to l.Span() for navigability. Anything
+// nested under l.Context() will be part of the same per-handler trace, and
+// is bounded by the work the handler does.
+//
+// One-shot setup work that genuinely belongs under the lifecycle span (for
+// example, the loader's per-component bootstrap tracing) can opt into
+// nesting by attaching the lifecycle span explicitly:
+//
+//	ctx := trace.ContextWithSpan(l.Context(), l.Span())
+//	_, span := tracer.Start(ctx, "Bootstrap.Step")
+//	defer span.End()
+//
+// This is appropriate only when the span count contributed by such code is
+// bounded by the lifecycle's own bootstrap, not by external traffic.
+package component

--- a/examples/direct/pong.go
+++ b/examples/direct/pong.go
@@ -6,10 +6,14 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"gocloud.dev/pubsub"
 
 	"github.com/danielorbach/go-component"
 )
+
+var pongTracer = otel.Tracer("github.com/danielorbach/go-component/examples/direct/pong")
 
 const PongAspect = "pong"
 
@@ -46,11 +50,21 @@ var PongComponent = &component.Descriptor{
 				}
 				msg.Ack()
 
+				// l.Context() detaches from the lifecycle span, so each
+				// invocation of this handler starts a new root trace whose
+				// size is bounded by the work below. The span link points
+				// back to the lifecycle for navigation in the trace backend.
+				ctx, span := pongTracer.Start(l.Context(), "pong.echo",
+					trace.WithSpanKind(trace.SpanKindConsumer),
+					trace.WithLinks(trace.Link{SpanContext: l.Span().SpanContext()}),
+				)
+
 				echo := "ECHO " + string(msg.Body)
-				err = pub.Send(l.Context(), &pubsub.Message{Body: []byte(echo)})
+				err = pub.Send(ctx, &pubsub.Message{Body: []byte(echo)})
 				if err != nil {
 					l.Error(fmt.Errorf("send pong: %w", err))
 				}
+				span.End()
 			}
 		})
 

--- a/kafkaloader/kafkaloader.go
+++ b/kafkaloader/kafkaloader.go
@@ -86,8 +86,16 @@ func (x Loader) Exec(l *component.L) {
 }
 
 func handleFootprint(l *component.L, msg *sarama.ConsumerMessage) {
+	// l.Context() detaches from the lifecycle span, so this is the root of an
+	// independent per-message trace — its size is bounded by the work done for
+	// one footprint, not by loader uptime. The span link points back to the
+	// lifecycle span for navigation in the trace backend.
+	//
 	// TODO: link to producer span
-	_, span := tracer.Start(l.Context(), "handleFootprint", trace.WithSpanKind(trace.SpanKindConsumer))
+	_, span := tracer.Start(l.Context(), "handleFootprint",
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithLinks(trace.Link{SpanContext: l.Span().SpanContext()}),
+	)
 	defer span.End()
 
 	fp, err := fileloader.UnmarshalFootprintJSON(msg.Value)

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 // TODO(@danielorbach): We think we can move Run() to lifecycle, let's consider
@@ -41,14 +42,25 @@ func execute(ctx context.Context, options lifecycleOptions) {
 	pprof.Do(ctx, pprof.Labels("component.name", options.Name()), func(ctx context.Context) {
 		done := make(chan struct{}) // make ahead of &L for better readability
 
+		// The lifecycle span captures observability for the lifecycle event itself
+		// (started, completed, errors). It is intentionally NOT propagated through
+		// l.Context(): handlers and other per-iteration work that derive spans from
+		// l.Context() should produce traces bounded by the work done per invocation,
+		// not by component uptime. The span is held on L for direct interaction
+		// (L.Error, L.Fatal, L.Span); child lifecycle spans nest under it via Fork,
+		// which re-attaches it to the context handed to the child execute.
+		//
 		// TODO: attach caller-defined attributes to the span
-		ctx, span := tracer.Start(ctx, options.SpanName())
+		_, span := tracer.Start(ctx, options.SpanName())
 		// the span ends when the lifecycle completes - this must be done asynchronously
 		go pprof.Do(ctx, pprof.Labels("component.reaper", "span"), func(context.Context) {
 			<-done
 			span.End()
 		})
 
+		// Detach any inherited lifecycle span from the user-facing ctx so spans
+		// started from l.Context() are roots of bounded traces.
+		ctx = trace.ContextWithSpan(ctx, noop.Span{})
 		ctx, cancel := context.WithCancelCause(ctx)
 		// do not leak a context.Context
 		go pprof.Do(ctx, pprof.Labels("component.reaper", "context"), func(context.Context) {
@@ -73,6 +85,7 @@ func execute(ctx context.Context, options lifecycleOptions) {
 			ctx:      ctx,
 			cancel:   cancel,
 			graceCtx: graceCtx,
+			span:     span,
 			done:     done,
 			common: common{
 				logger:         options.Logger(),
@@ -135,6 +148,13 @@ type L struct {
 	cancel   context.CancelCauseFunc
 	graceCtx context.Context // cancelled when stopping is closed
 
+	// span is the lifecycle span. It is not propagated through ctx; spans
+	// started from l.Context() are roots, bounded to per-invocation work.
+	// See Span() for how to interact with it (set attributes, link from
+	// per-handler traces) and the package documentation for the framework's
+	// tracing contract.
+	span trace.Span
+
 	done chan struct{} // closed when all lifecycle goroutines and cleanup functions have finished
 	wg   sync.WaitGroup
 
@@ -172,6 +192,22 @@ func (l *L) GraceContext() context.Context {
 
 func (l *L) Done() <-chan struct{} {
 	return l.done
+}
+
+// Span returns the lifecycle span. Its lifetime spans the entire component
+// uptime, so it must NOT be used as a parent for per-handler or per-iteration
+// work — that would produce traces that grow without bound and saturate trace
+// backends. Use it to record lifecycle observability (attributes, events,
+// errors) and to link short-lived handler traces back to the lifecycle for
+// navigation in trace backends:
+//
+//	_, handler := tracer.Start(l.Context(), "consume",
+//		trace.WithLinks(trace.Link{SpanContext: l.Span().SpanContext()}))
+//
+// Spans started from l.Context() are roots of independent traces — that is the
+// per-handler scope. The lifecycle span is the lifecycle scope.
+func (l *L) Span() trace.Span {
+	return l.span
 }
 
 // exec should be called in its own goroutine and only once.
@@ -268,7 +304,12 @@ func (l *L) Fork(name string, procedure Procedure, opts ...ForkOption) {
 	}
 
 	l.wg.Add(1)
-	go pprof.Do(l.ctx, pprof.Labels("parent-component", l.name), func(ctx context.Context) {
+	// Re-attach the lifecycle span so the child's lifecycle span nests under
+	// it. Lifecycle spans are the only spans the framework guarantees nest
+	// (parent-component to child-component); per-handler spans started from
+	// l.Context() are roots by design. See package documentation.
+	forkCtx := trace.ContextWithSpan(l.ctx, l.span)
+	go pprof.Do(forkCtx, pprof.Labels("parent-component", l.name), func(ctx context.Context) {
 		defer l.wg.Done()
 		fullName := l.name + "/" + name // the child's name is appended to that of the parent (also used for tracing)
 		options := lifecycleOptions{
@@ -397,8 +438,7 @@ func (l *L) Log(args ...any) {
 
 func (l *L) Error(err error) {
 	l.Logf("error: %v", err)
-	span := trace.SpanFromContext(l.ctx)
-	span.RecordError(err)
+	l.span.RecordError(err)
 }
 
 func (l *L) Errorf(format string, a ...any) {
@@ -425,9 +465,8 @@ func (l *L) Fatal(err error) {
 
 	l.Logf("fatal error: %v", err)
 	// marking the span as errored is a good practice
-	span := trace.SpanFromContext(l.ctx)
-	span.RecordError(err)
-	span.SetStatus(codes.Error, err.Error())
+	l.span.RecordError(err)
+	l.span.SetStatus(codes.Error, err.Error())
 	// cancel the lifecycle context because a fatal error is unrecoverable, hence
 	// there is no point in continuing.
 	l.cancel(fmt.Errorf("fatality: %w", err))

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -102,7 +102,10 @@ func Load(footprint Footprint, opts ...component.Option) {
 }
 
 func loadSharedResources(l *component.L) {
-	_, span := tracer.Start(l.Context(), "Load.SharedResources")
+	// The loader is the one place where short-lived setup spans are nested
+	// under the lifecycle span: this is one-shot work whose count is bounded
+	// by the loader's own Bootstrap, not by message volume.
+	_, span := tracer.Start(trace.ContextWithSpan(l.Context(), l.Span()), "Load.SharedResources")
 	defer span.End()
 
 	if CPUProfile != "" {
@@ -180,7 +183,7 @@ func loadSharedResources(l *component.L) {
 }
 
 func loadFootprintComponents(l *component.L, footprint Footprint) {
-	_, span := tracer.Start(l.Context(), "Load.FootprintComponents")
+	_, span := tracer.Start(trace.ContextWithSpan(l.Context(), l.Span()), "Load.FootprintComponents")
 	defer span.End()
 
 	// TODO: skip loading based on Location
@@ -324,8 +327,7 @@ func (c *Claim) Exec(l *component.L) {
 		panic("loaded claim can be executed only once")
 	}
 
-	span := trace.SpanFromContext(l.Context())
-	span.SetAttributes(
+	l.Span().SetAttributes(
 		attribute.String("component.name", c.Component.Name),
 		attribute.String("component.binding", fmt.Sprintf("%+v", c.Binding)),
 		attribute.String("component.options", fmt.Sprintf("%+v", c.Options)),

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -1,0 +1,155 @@
+package component
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// installRecorder swaps in an in-memory tracer provider for the duration of t,
+// restoring the previous global at cleanup. It returns the recorder so tests
+// can inspect started/ended spans.
+//
+// OpenTelemetry's global package binds delegating tracers to the first
+// TracerProvider registered after package init (sync.Once on the delegate),
+// so installRecorder must be called once at the top-level test rather than
+// once per subtest. See https://pkg.go.dev/go.opentelemetry.io/otel/internal/global.
+func installRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+	return sr
+}
+
+// findSpan looks up an ended span by its name. Returns nil if not found.
+func findSpan(spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
+	if i := slices.IndexFunc(spans, func(s sdktrace.ReadOnlySpan) bool { return s.Name() == name }); i >= 0 {
+		return spans[i]
+	}
+	return nil
+}
+
+// waitForSpan polls sr.Ended() until a span with the given name appears. The
+// lifecycle ends its span asynchronously via a reaper goroutine, so the span
+// may not be present when Run() returns.
+func waitForSpan(t *testing.T, sr *tracetest.SpanRecorder, name string) sdktrace.ReadOnlySpan {
+	t.Helper()
+	deadline := time.Now().Add(SyncTimeout)
+	for {
+		if s := findSpan(sr.Ended(), name); s != nil {
+			return s
+		}
+		if time.Now().After(deadline) {
+			started := make([]string, 0, len(sr.Started()))
+			for _, s := range sr.Started() {
+				started = append(started, s.Name())
+			}
+			ended := make([]string, 0, len(sr.Ended()))
+			for _, s := range sr.Ended() {
+				ended = append(ended, s.Name())
+			}
+			t.Fatalf("timed out waiting for span %q (started=%v, ended=%v)", name, started, ended)
+			return nil
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestTracingContract(t *testing.T) {
+	sr := installRecorder(t)
+	handlerTracer := otel.Tracer("test/handler")
+
+	t.Run("HandlerSpansAreRoots", func(t *testing.T) {
+		RunProc(func(l *L) {
+			_, span := handlerTracer.Start(l.Context(), "tc.handler.work")
+			span.End()
+		}, WithName("tc.solo"))
+
+		handler := waitForSpan(t, sr, "tc.handler.work")
+		// A span started from l.Context() must be the root of its own trace.
+		// If it inherited the lifecycle span as parent, downstream backends
+		// would see traces that grow with component uptime — see Issue #56.
+		if handler.Parent().IsValid() {
+			t.Errorf("handler span has parent %v, want root", handler.Parent())
+		}
+	})
+
+	t.Run("ChildLifecycleNestsUnderParent", func(t *testing.T) {
+		RunProc(func(l *L) {
+			done := make(chan struct{})
+			l.Fork("child", Proc(func(*L) { close(done) }))
+			<-done
+		}, WithName("tc.parent"))
+
+		parent := waitForSpan(t, sr, "tc.parent")
+		child := waitForSpan(t, sr, "tc.parent/child")
+		// Child lifecycle spans nest under parent lifecycle spans — this is
+		// the only nesting the framework guarantees.
+		if child.Parent().SpanID() != parent.SpanContext().SpanID() {
+			t.Errorf("child lifecycle parent %v, want %v", child.Parent().SpanID(), parent.SpanContext().SpanID())
+		}
+	})
+
+	t.Run("HandlerSpanInChildIsRoot", func(t *testing.T) {
+		// In a forked lifecycle, l.Context() is still detached from any
+		// lifecycle span, so per-handler spans within the child also start
+		// new traces.
+		RunProc(func(l *L) {
+			done := make(chan struct{})
+			l.Fork("child", Proc(func(l *L) {
+				_, span := handlerTracer.Start(l.Context(), "tc.child.handler")
+				span.End()
+				close(done)
+			}))
+			<-done
+		}, WithName("tc.parent2"))
+
+		handler := waitForSpan(t, sr, "tc.child.handler")
+		if handler.Parent().IsValid() {
+			t.Errorf("child handler span has parent %v, want root", handler.Parent())
+		}
+	})
+
+	t.Run("LinkToLifecycleSpan", func(t *testing.T) {
+		// Per-handler instrumentation should link back to the lifecycle for
+		// navigability in the trace backend. Verify that the link mechanism
+		// works end-to-end through L.Span().
+		var lifecycleSC trace.SpanContext
+		RunProc(func(l *L) {
+			lifecycleSC = l.Span().SpanContext()
+			_, span := handlerTracer.Start(l.Context(), "tc.handler.linked",
+				trace.WithLinks(trace.Link{SpanContext: lifecycleSC}),
+			)
+			span.End()
+		}, WithName("tc.linked"))
+
+		handler := waitForSpan(t, sr, "tc.handler.linked")
+		links := handler.Links()
+		if len(links) != 1 {
+			t.Fatalf("got %d links, want 1", len(links))
+		}
+		if links[0].SpanContext.SpanID() != lifecycleSC.SpanID() {
+			t.Errorf("link SpanID %v, want %v", links[0].SpanContext.SpanID(), lifecycleSC.SpanID())
+		}
+	})
+
+	t.Run("LifecycleSpanIsValid", func(t *testing.T) {
+		// L.Span() must return a usable span that records into the configured
+		// tracer provider — Error and Fatal call RecordError on it.
+		var sc trace.SpanContext
+		RunProc(func(l *L) {
+			sc = l.Span().SpanContext()
+		}, WithName("tc.valid"))
+		if !sc.IsValid() {
+			t.Errorf("L.Span() SpanContext is invalid, want a recording span")
+		}
+	})
+}


### PR DESCRIPTION
This PR preserves the first attempt at resolving #56 as a reference. It is opened as a draft and closed immediately; the goal is a persistent GitHub URL the merged PR can cite.

The attempt detaches the lifecycle span from `l.Context()` so handler-derived spans become roots, but keeps the lifecycle span itself open for the duration of the component. `L.Span()` exposes the span for callers that want to record onto it (loader's `Claim.Exec`) or use its `SpanContext` as a span link target. The shape was abandoned in favor of dropping the long-lived span entirely; the trade-offs that drove the change are captured in the discussion on the merged PR.

Not for review. Not for merge.