### PR TITLE
Test concurrent component lifecycles deterministically under synctest

### DIFF
--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -220,11 +220,7 @@ func TestL_Fatal(t *testing.T) {
 						// of the lifecycle - calls to L.Fatal from other goroutines do not
 						// (and cannot) affect the primary goroutine.
 						for range goroutines {
-							select {
-							case <-done:
-							case <-time.After(SyncTimeout):
-								t.Fatal("timeout: L.Fatal() did not call deferred functions in goroutines")
-							}
+							<-done
 						}
 					}, WithName(t.Name()))
 				})

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -111,70 +111,76 @@ func TestL_Cleanup(t *testing.T) {
 	t.Parallel() // parallel because of a subtest which must time out to pass (also parallel)
 
 	t.Run("Order", func(t *testing.T) {
-		const count = 100
-		order := make(map[int]int) // map: cleanupFn#index -> called order
-		RunProc(func(l *L) {
-			for i := range count {
-				index := i
-				l.Cleanup(func() {
-					order[index] = len(order)
-				})
+		synctest.Test(t, func(t *testing.T) {
+			const count = 100
+			order := make(map[int]int) // map: cleanupFn#index -> called order
+			RunProc(func(l *L) {
+				for i := range count {
+					index := i
+					l.Cleanup(func() {
+						order[index] = len(order)
+					})
+				}
+			}, WithName(t.Name()))
+			if len(order) != count {
+				t.Fatalf("cleanup functions were not called: got %d, want %d", len(order), count)
 			}
-		}, WithName(t.Name()))
-		if len(order) != count {
-			t.Fatalf("cleanup functions were not called: got %d, want %d", len(order), count)
-		}
-		for index, called := range order {
-			if called != count-index-1 {
-				t.Errorf("cleanup#%d was called out of order: got %d, want %d", index, called, count-index-1)
+			for index, called := range order {
+				if called != count-index-1 {
+					t.Errorf("cleanup#%d was called out of order: got %d, want %d", index, called, count-index-1)
+				}
 			}
-		}
+		})
 	})
 
 	t.Run("CalledAfterCompletion", func(t *testing.T) {
-		// capture l variable to simulate a closure over it
-		// (may happen in real code when storing a reference to
-		// the lifecycle)
-		var capture *L
-		RunProc(func(l *L) { capture = l }, WithName(t.Name()))
-		// calling L.Cleanup after the lifecycle has completed should panic
-		defer func() {
-			if reason := recover(); reason == nil {
-				t.Error("L.Cleanup() must panic if called after component completion")
-			}
-		}()
-		capture.Cleanup(func() {})
+		synctest.Test(t, func(t *testing.T) {
+			// capture l variable to simulate a closure over it
+			// (may happen in real code when storing a reference to
+			// the lifecycle)
+			var capture *L
+			RunProc(func(l *L) { capture = l }, WithName(t.Name()))
+			// calling L.Cleanup after the lifecycle has completed should panic
+			defer func() {
+				if reason := recover(); reason == nil {
+					t.Error("L.Cleanup() must panic if called after component completion")
+				}
+			}()
+			capture.Cleanup(func() {})
+		})
 	})
 
 	t.Run("SynchronisesBeforeSubComponents", func(t *testing.T) {
 		t.Parallel()
-		ctx, cancel := context.WithTimeout(context.Background(), 180*time.Millisecond)
-		defer cancel()
-		RunProc(func(l *L) {
-			canary := make(chan struct{})
-			l.Cleanup(func() {
-				// send a signal to the canary channel to indicate that the cleanup function has
-				// been called. this case blocks indefinitely if the subcomponent has already
-				// returned
-				select {
-				case <-ctx.Done():
-				case canary <- struct{}{}:
-					t.Error("Cleanup(): cleanup function was called before the subcomponent completed")
-				}
-			})
-			l.Go("canary", func(*L) {
-				// yield to increase the change of the cleanup being called in case the test will
-				// have failed
-				runtime.Gosched()
-				// wait for the cleanup to be called - we only know it has not been called if the
-				// context times out
-				select {
-				case <-ctx.Done():
-				case <-canary:
-					t.Error("Go(): cleanup function was called before the subcomponent completed")
-				}
-			})
-		}, WithName(t.Name()), WithContext(ctx))
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 180*time.Millisecond)
+			defer cancel()
+			RunProc(func(l *L) {
+				canary := make(chan struct{})
+				l.Cleanup(func() {
+					// send a signal to the canary channel to indicate that the cleanup function has
+					// been called. this case blocks indefinitely if the subcomponent has already
+					// returned
+					select {
+					case <-ctx.Done():
+					case canary <- struct{}{}:
+						t.Error("Cleanup(): cleanup function was called before the subcomponent completed")
+					}
+				})
+				l.Go("canary", func(*L) {
+					// yield to increase the change of the cleanup being called in case the test will
+					// have failed
+					runtime.Gosched()
+					// wait for the cleanup to be called - we only know it has not been called if the
+					// context times out
+					select {
+					case <-ctx.Done():
+					case <-canary:
+						t.Error("Go(): cleanup function was called before the subcomponent completed")
+					}
+				})
+			}, WithName(t.Name()), WithContext(ctx))
+		})
 	})
 }
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -150,33 +149,37 @@ func TestL_Cleanup(t *testing.T) {
 
 	t.Run("SynchronisesBeforeSubComponents", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 180*time.Millisecond)
-			defer cancel()
-			RunProc(func(l *L) {
-				canary := make(chan struct{})
-				l.Cleanup(func() {
-					// send a signal to the canary channel to indicate that the cleanup function has
-					// been called. this case blocks indefinitely if the subcomponent has already
-					// returned
-					select {
-					case <-ctx.Done():
-					case canary <- struct{}{}:
-						t.Error("Cleanup(): cleanup function was called before the subcomponent completed")
-					}
-				})
-				l.Go("canary", func(*L) {
-					// yield to increase the change of the cleanup being called in case the test will
-					// have failed
-					runtime.Gosched()
-					// wait for the cleanup to be called - we only know it has not been called if the
-					// context times out
-					select {
-					case <-ctx.Done():
-					case <-canary:
-						t.Error("Go(): cleanup function was called before the subcomponent completed")
-					}
-				})
-			}, WithName(t.Name()), WithContext(ctx))
+			var cleanedUp atomic.Bool
+			release := make(chan struct{})
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				RunProc(func(l *L) {
+					l.Cleanup(func() { cleanedUp.Store(true) })
+					l.Go("subcomponent", func(*L) {
+						// stay blocked so the lifecycle - and therefore its
+						// cleanup - cannot complete until we release it below
+						<-release
+					})
+				}, WithName(t.Name()))
+			}()
+
+			// synctest.Wait blocks until every other goroutine in the bubble is
+			// durably blocked: the subcomponent parked on <-release, the
+			// lifecycle waiting on it in wg.Wait, and the reapers idle. At that
+			// quiescent point a cleanup that had run early would already be
+			// observable, so this asserts the negative directly rather than
+			// inferring it from a deadline that never fires.
+			synctest.Wait()
+			if cleanedUp.Load() {
+				t.Error("cleanup ran before the subcomponent completed")
+			}
+
+			close(release) // let the subcomponent finish so the lifecycle completes
+			<-done
+			if !cleanedUp.Load() {
+				t.Error("cleanup did not run after the subcomponent completed")
+			}
 		})
 	})
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -374,13 +374,9 @@ func TestL_Context(t *testing.T) {
 			defer cancel()
 			RunProc(func(l *L) {
 				// wait for context to expire
-				select {
-				case <-l.Context().Done():
-					if !errors.Is(l.Context().Err(), context.DeadlineExceeded) {
-						t.Error("context deadline should have been exceeded")
-					}
-				case <-time.After(SyncTimeout):
-					t.Error("timeout: context should have been canceled by now")
+				<-l.Context().Done()
+				if !errors.Is(l.Context().Err(), context.DeadlineExceeded) {
+					t.Error("context deadline should have been exceeded")
 				}
 			}, WithName(t.Name()), WithContext(ctx))
 		})

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -108,8 +108,6 @@ func TestL_Run(t *testing.T) {
 }
 
 func TestL_Cleanup(t *testing.T) {
-	t.Parallel() // parallel because of a subtest which must time out to pass (also parallel)
-
 	t.Run("Order", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			const count = 100
@@ -151,7 +149,6 @@ func TestL_Cleanup(t *testing.T) {
 	})
 
 	t.Run("SynchronisesBeforeSubComponents", func(t *testing.T) {
-		t.Parallel()
 		synctest.Test(t, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 180*time.Millisecond)
 			defer cancel()

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -367,7 +367,6 @@ func TestL_Context(t *testing.T) {
 		})
 	})
 	t.Run("DeadlineExceeded", func(t *testing.T) {
-		t.Parallel()
 		synctest.Test(t, func(t *testing.T) {
 			const timeout = time.Millisecond
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/danielorbach/go-component"
 )
 
-// SyncTimeout is the maximum time a test is allowed to wait for a
-// synchronisation event to occur.
-const SyncTimeout = time.Second
-
 func TestDrivenDevelopment(t *testing.T) {
 	t.Run("FunctionExecution", func(t *testing.T) {
 		tests := []struct {
@@ -494,7 +490,7 @@ func TestL_Stop(t *testing.T) {
 				go func() {
 					// Stop() blocks, but we know it honors the given timeout
 					// because of the previous test ("Ignored")
-					stopped <- l.Stop(SyncTimeout)
+					stopped <- l.Stop(time.Second)
 				}()
 				// returning after waiting for Stopping() to close
 				// completes the lifecycle

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -450,15 +450,17 @@ func TestL_Name(t *testing.T) {
 }
 
 func TestL_Terminate(t *testing.T) {
-	RunProc(func(l *L) {
-		l.Terminate()
-		if !errors.Is(l.Context().Err(), context.Canceled) {
-			t.Error("context should have been canceled")
-		}
-		if cause := context.Cause(l.Context()); !errors.Is(cause, ErrTerminated) {
-			t.Errorf("Cause() = %v, want %v", cause, ErrTerminated)
-		}
-	}, WithName(t.Name()))
+	synctest.Test(t, func(t *testing.T) {
+		RunProc(func(l *L) {
+			l.Terminate()
+			if !errors.Is(l.Context().Err(), context.Canceled) {
+				t.Error("context should have been canceled")
+			}
+			if cause := context.Cause(l.Context()); !errors.Is(cause, ErrTerminated) {
+				t.Errorf("Cause() = %v, want %v", cause, ErrTerminated)
+			}
+		}, WithName(t.Name()))
+	})
 }
 
 func TestL_Stop(t *testing.T) {

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -83,11 +83,7 @@ func TestL_Run(t *testing.T) {
 					})
 				}
 				for range goroutines {
-					select {
-					case <-done:
-					case <-time.After(SyncTimeout):
-						t.Fatal("timeout: timed out while waiting for sub-component to complete")
-					}
+					<-done
 				}
 			}, WithName(t.Name()))
 		})

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -563,23 +563,25 @@ func TestL_Stop(t *testing.T) {
 }
 
 func TestL_Continue(t *testing.T) {
-	stopper := make(chan struct{})
-	RunProc(func(l *L) {
-		if !l.Continue() {
-			t.Error("Continue() should have returned true")
-		}
+	synctest.Test(t, func(t *testing.T) {
+		stopper := make(chan struct{})
+		RunProc(func(l *L) {
+			if !l.Continue() {
+				t.Error("Continue() should have returned true")
+			}
 
-		close(stopper) // stop the lifecycle
-		// synchronise with the lifecycle signal propagation (otherwise Continue() might
-		// return before the lifecycle has had a chance to propagate the stop signal)
-		select {
-		case <-l.Stopping():
-		case <-time.After(SyncTimeout):
-			t.Fatal("timeout: lifecycle stop did not synchronise with Continue()")
-		}
+			close(stopper) // stop the lifecycle
+			// synchronise with the lifecycle signal propagation (otherwise Continue() might
+			// return before the lifecycle has had a chance to propagate the stop signal)
+			select {
+			case <-l.Stopping():
+			case <-time.After(SyncTimeout):
+				t.Fatal("timeout: lifecycle stop did not synchronise with Continue()")
+			}
 
-		if l.Continue() {
-			t.Error("Continue() should have returned false")
-		}
-	}, WithName(t.Name()), WithStopper(stopper))
+			if l.Continue() {
+				t.Error("Continue() should have returned false")
+			}
+		}, WithName(t.Name()), WithStopper(stopper))
+	})
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -480,13 +480,8 @@ func TestL_Stop(t *testing.T) {
 					stopped <- l.Stop(180 * time.Millisecond)
 				}()
 				// block the lifecycle until Stop() returns
-				select {
-				case ok := <-stopped:
-					if ok {
-						t.Error("Stop() should have failed")
-					}
-				case <-time.After(SyncTimeout):
-					t.Error("timeout: Stop() should have returned by now")
+				if ok := <-stopped; ok {
+					t.Error("Stop() should have failed")
 				}
 			}, WithName(t.Name()))
 		})
@@ -531,16 +526,9 @@ func TestL_Stop(t *testing.T) {
 					}(timeouts[i])
 				}
 				// wait for all Stop() calls to return
-				timer := time.NewTimer(SyncTimeout)
-				defer timer.Stop()
 				for i := range timeouts {
-					select {
-					case ok := <-stopped:
-						if ok {
-							t.Errorf("Stop() should have failed (already stopped: %d/%d)", i, len(timeouts))
-						}
-					case <-timer.C:
-						t.Fatal("timeout: Stop() did not return")
+					if ok := <-stopped; ok {
+						t.Errorf("Stop() should have failed (already stopped: %d/%d)", i, len(timeouts))
 					}
 				}
 			}, WithName(t.Name()))

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -73,37 +73,41 @@ func TestDrivenDevelopment(t *testing.T) {
 
 func TestL_Run(t *testing.T) {
 	t.Run("Concurrent", func(t *testing.T) {
-		const goroutines = 16
-		RunProc(func(l *L) {
-			done := make(chan struct{})
-			for i := range goroutines {
-				l.Go("child#"+strconv.Itoa(i), func(l *L) {
-					done <- struct{}{}
-				})
-			}
-			for range goroutines {
-				select {
-				case <-done:
-				case <-time.After(SyncTimeout):
-					t.Fatal("timeout: timed out while waiting for sub-component to complete")
+		synctest.Test(t, func(t *testing.T) {
+			const goroutines = 16
+			RunProc(func(l *L) {
+				done := make(chan struct{})
+				for i := range goroutines {
+					l.Go("child#"+strconv.Itoa(i), func(l *L) {
+						done <- struct{}{}
+					})
 				}
-			}
-		}, WithName(t.Name()))
+				for range goroutines {
+					select {
+					case <-done:
+					case <-time.After(SyncTimeout):
+						t.Fatal("timeout: timed out while waiting for sub-component to complete")
+					}
+				}
+			}, WithName(t.Name()))
+		})
 	})
 
 	t.Run("CalledAfterCompletion", func(t *testing.T) {
-		// capture l variable to simulate a closure over it
-		// (may happen in real code when storing a reference to
-		// the lifecycle)
-		var capture *L
-		RunProc(func(l *L) { capture = l }, WithName(t.Name()))
-		// calling L.Go after the lifecycle has completed should panic
-		defer func() {
-			if reason := recover(); reason == nil {
-				t.Error("L.Go() must panic if called after component completion")
-			}
-		}()
-		capture.Go("<irrelevant>", func(*L) {})
+		synctest.Test(t, func(t *testing.T) {
+			// capture l variable to simulate a closure over it
+			// (may happen in real code when storing a reference to
+			// the lifecycle)
+			var capture *L
+			RunProc(func(l *L) { capture = l }, WithName(t.Name()))
+			// calling L.Go after the lifecycle has completed should panic
+			defer func() {
+				if reason := recover(); reason == nil {
+					t.Error("L.Go() must panic if called after component completion")
+				}
+			}()
+			capture.Go("<irrelevant>", func(*L) {})
+		})
 	})
 }
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -573,11 +573,7 @@ func TestL_Continue(t *testing.T) {
 			close(stopper) // stop the lifecycle
 			// synchronise with the lifecycle signal propagation (otherwise Continue() might
 			// return before the lifecycle has had a chance to propagate the stop signal)
-			select {
-			case <-l.Stopping():
-			case <-time.After(SyncTimeout):
-				t.Fatal("timeout: lifecycle stop did not synchronise with Continue()")
-			}
+			<-l.Stopping()
 
 			if l.Continue() {
 				t.Error("Continue() should have returned false")

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -1,4 +1,4 @@
-package component
+package component_test
 
 import (
 	"context"
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"testing/synctest"
 	"time"
+
+	"github.com/danielorbach/go-component"
 )
 
 // SyncTimeout is the maximum time a test is allowed to wait for a
@@ -19,30 +21,30 @@ func TestDrivenDevelopment(t *testing.T) {
 	t.Run("FunctionExecution", func(t *testing.T) {
 		tests := []struct {
 			name      string
-			fn        func(*L)
+			fn        func(*component.L)
 			wantAbort bool
 		}{
 			{
 				name: "NoOp",
-				fn:   func(*L) {},
+				fn:   func(*component.L) {},
 			},
 			{
 				name: "Error",
-				fn: func(l *L) {
+				fn: func(l *component.L) {
 					l.Error(fmt.Errorf("test error"))
 				},
 				wantAbort: false,
 			},
 			{
 				name: "Fatal",
-				fn: func(l *L) {
+				fn: func(l *component.L) {
 					l.Fatal(fmt.Errorf("test error"))
 				},
 				wantAbort: true,
 			},
 			{
 				name: "FatalWhileCleanup",
-				fn: func(l *L) {
+				fn: func(l *component.L) {
 					l.Cleanup(func() {
 						l.Fatal(fmt.Errorf("test error"))
 					})
@@ -54,10 +56,10 @@ func TestDrivenDevelopment(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				synctest.Test(t, func(t *testing.T) {
 					var called bool
-					RunProc(func(l *L) {
+					component.RunProc(func(l *component.L) {
 						tt.fn(l)
 						called = true
-					}, WithName(t.Name()))
+					}, component.WithName(t.Name()))
 					if tt.wantAbort && called {
 						t.Error("execution should have been aborted")
 					}
@@ -74,17 +76,17 @@ func TestL_Run(t *testing.T) {
 	t.Run("Concurrent", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			const goroutines = 16
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				done := make(chan struct{})
 				for i := range goroutines {
-					l.Go("child#"+strconv.Itoa(i), func(l *L) {
+					l.Go("child#"+strconv.Itoa(i), func(l *component.L) {
 						done <- struct{}{}
 					})
 				}
 				for range goroutines {
 					<-done
 				}
-			}, WithName(t.Name()))
+			}, component.WithName(t.Name()))
 		})
 	})
 
@@ -93,15 +95,15 @@ func TestL_Run(t *testing.T) {
 			// capture l variable to simulate a closure over it
 			// (may happen in real code when storing a reference to
 			// the lifecycle)
-			var capture *L
-			RunProc(func(l *L) { capture = l }, WithName(t.Name()))
+			var capture *component.L
+			component.RunProc(func(l *component.L) { capture = l }, component.WithName(t.Name()))
 			// calling L.Go after the lifecycle has completed should panic
 			defer func() {
 				if reason := recover(); reason == nil {
 					t.Error("L.Go() must panic if called after component completion")
 				}
 			}()
-			capture.Go("<irrelevant>", func(*L) {})
+			capture.Go("<irrelevant>", func(*component.L) {})
 		})
 	})
 }
@@ -111,14 +113,14 @@ func TestL_Cleanup(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			const count = 100
 			order := make(map[int]int) // map: cleanupFn#index -> called order
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				for i := range count {
 					index := i
 					l.Cleanup(func() {
 						order[index] = len(order)
 					})
 				}
-			}, WithName(t.Name()))
+			}, component.WithName(t.Name()))
 			if len(order) != count {
 				t.Fatalf("cleanup functions were not called: got %d, want %d", len(order), count)
 			}
@@ -135,8 +137,8 @@ func TestL_Cleanup(t *testing.T) {
 			// capture l variable to simulate a closure over it
 			// (may happen in real code when storing a reference to
 			// the lifecycle)
-			var capture *L
-			RunProc(func(l *L) { capture = l }, WithName(t.Name()))
+			var capture *component.L
+			component.RunProc(func(l *component.L) { capture = l }, component.WithName(t.Name()))
 			// calling L.Cleanup after the lifecycle has completed should panic
 			defer func() {
 				if reason := recover(); reason == nil {
@@ -154,14 +156,14 @@ func TestL_Cleanup(t *testing.T) {
 			done := make(chan struct{})
 			go func() {
 				defer close(done)
-				RunProc(func(l *L) {
+				component.RunProc(func(l *component.L) {
 					l.Cleanup(func() { cleanedUp.Store(true) })
-					l.Go("subcomponent", func(*L) {
+					l.Go("subcomponent", func(*component.L) {
 						// stay blocked so the lifecycle - and therefore its
 						// cleanup - cannot complete until we release it below
 						<-release
 					})
-				}, WithName(t.Name()))
+				}, component.WithName(t.Name()))
 			}()
 
 			// synctest.Wait blocks until every other goroutine in the bubble is
@@ -187,7 +189,7 @@ func TestL_Cleanup(t *testing.T) {
 func TestL_Fatal(t *testing.T) {
 	t.Run("CalledFromNestedFunctions", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				func() {
 					func() {
 						func() {
@@ -199,7 +201,7 @@ func TestL_Fatal(t *testing.T) {
 					t.Error("L.Fatal() should have aborted execution (nesting level -2)")
 				}()
 				t.Error("L.Fatal() should have aborted execution (nesting level -3)")
-			}, WithName(t.Name()))
+			}, component.WithName(t.Name()))
 		})
 	})
 
@@ -207,7 +209,7 @@ func TestL_Fatal(t *testing.T) {
 		for _, goroutines := range []int{1, 2, 16} {
 			t.Run(fmt.Sprintf("ConcurrentCalls=%d", goroutines), func(t *testing.T) {
 				synctest.Test(t, func(t *testing.T) {
-					RunProc(func(l *L) {
+					component.RunProc(func(l *component.L) {
 						done := make(chan struct{})
 						for i := range goroutines {
 							go func(index int) {
@@ -222,7 +224,7 @@ func TestL_Fatal(t *testing.T) {
 						for range goroutines {
 							<-done
 						}
-					}, WithName(t.Name()))
+					}, component.WithName(t.Name()))
 				})
 			})
 		}
@@ -231,11 +233,11 @@ func TestL_Fatal(t *testing.T) {
 	t.Run("CallsCleanupFunctions", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			var called bool
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				l.Cleanup(func() { called = true })
 				l.Fatal(fmt.Errorf("test error"))
 				t.Error("L.Fatal() should have aborted execution")
-			}, WithName(t.Name()))
+			}, component.WithName(t.Name()))
 			if !called {
 				t.Error("Cleanup() function should have been called")
 			}
@@ -249,7 +251,7 @@ func TestL_Fatal(t *testing.T) {
 		// to ensure this test does not pass by accident due to human error.
 		var calledBeforeFatal, calledAfterFatal bool
 		synctest.Test(t, func(t *testing.T) {
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				l.Cleanup(func() {
 					// scheduled before Fatal(), but executed after because
 					// cleanup functions are executed in reverse order
@@ -264,7 +266,7 @@ func TestL_Fatal(t *testing.T) {
 					// cleanup functions are executed in reverse order
 					calledBeforeFatal = true
 				})
-			}, WithName(t.Name()))
+			}, component.WithName(t.Name()))
 		})
 		if !calledBeforeFatal {
 			t.Error("Cleanup() function should have been called before L.Fatal()")
@@ -278,17 +280,17 @@ func TestL_Fatal(t *testing.T) {
 		var sentinel = fmt.Errorf("test error value")
 		tests := []struct {
 			name string
-			fn   func(*L)
+			fn   func(*component.L)
 		}{
 			{
 				name: "Directly",
-				fn: func(l *L) {
+				fn: func(l *component.L) {
 					l.Fatal(sentinel)
 				},
 			},
 			{
 				name: "Goroutine",
-				fn: func(l *L) {
+				fn: func(l *component.L) {
 					done := make(chan struct{})
 					go func() {
 						defer close(done)
@@ -299,7 +301,7 @@ func TestL_Fatal(t *testing.T) {
 			},
 			{
 				name: "Cleanup",
-				fn: func(l *L) {
+				fn: func(l *component.L) {
 					l.Cleanup(func() {
 						l.Fatal(sentinel)
 					})
@@ -309,7 +311,7 @@ func TestL_Fatal(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				synctest.Test(t, func(t *testing.T) {
-					RunProc(func(l *L) {
+					component.RunProc(func(l *component.L) {
 						l.Cleanup(func() {
 							if !errors.Is(l.Context().Err(), context.Canceled) {
 								t.Error("context should have been canceled")
@@ -320,7 +322,7 @@ func TestL_Fatal(t *testing.T) {
 							}
 						})
 						tt.fn(l)
-					}, WithName(t.Name()))
+					}, component.WithName(t.Name()))
 				})
 			})
 		}
@@ -331,8 +333,8 @@ func TestL_Fatal(t *testing.T) {
 			// capture l variable to simulate a closure over it
 			// (may happen in real code when storing a reference to
 			// the lifecycle)
-			var capture *L
-			RunProc(func(l *L) { capture = l }, WithName(t.Name()))
+			var capture *component.L
+			component.RunProc(func(l *component.L) { capture = l }, component.WithName(t.Name()))
 			// calling L.Fatal after the lifecycle has completed should panic
 			defer func() {
 				if reason := recover(); reason == nil {
@@ -347,23 +349,23 @@ func TestL_Fatal(t *testing.T) {
 func TestL_Context(t *testing.T) {
 	t.Run("Background", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				_, ok := l.Context().Deadline()
 				if ok {
 					t.Error("context should not have a deadline")
 				}
-			}, WithName(t.Name()))
+			}, component.WithName(t.Name()))
 		})
 	})
 	t.Run("Canceled", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				if !errors.Is(l.Context().Err(), context.Canceled) {
 					t.Error("context should have been canceled")
 				}
-			}, WithName(t.Name()), WithContext(ctx))
+			}, component.WithName(t.Name()), component.WithContext(ctx))
 		})
 	})
 	t.Run("DeadlineExceeded", func(t *testing.T) {
@@ -371,13 +373,13 @@ func TestL_Context(t *testing.T) {
 			const timeout = time.Millisecond
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				// wait for context to expire
 				<-l.Context().Done()
 				if !errors.Is(l.Context().Err(), context.DeadlineExceeded) {
 					t.Error("context deadline should have been exceeded")
 				}
-			}, WithName(t.Name()), WithContext(ctx))
+			}, component.WithName(t.Name()), component.WithContext(ctx))
 		})
 	})
 }
@@ -385,81 +387,81 @@ func TestL_Context(t *testing.T) {
 func TestL_Name(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				if l.Name() != "" {
 					t.Errorf("parent Name() = %q, want %q", l.Name(), "")
 				}
 				// see child initialization for why this is "/"
-				l.Go("", func(l *L) {
+				l.Go("", func(l *component.L) {
 					if l.Name() != "/" {
 						t.Errorf("child Name() = %q, want %q", l.Name(), "./")
 					}
 				})
-			}, WithName(""))
+			}, component.WithName(""))
 		})
 	})
 
 	t.Run("Sanity", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				if l.Name() != "TestLifecycle" {
 					t.Errorf("Name() = %q, want %q", l.Name(), "TestLifecycle")
 				}
-				l.Go("Child", func(l *L) {
+				l.Go("Child", func(l *component.L) {
 					if l.Name() != "TestLifecycle/Child" {
 						t.Errorf("Name() = %q, want %q", l.Name(), "TestLifecycle/Child")
 					}
 				})
-			}, WithName("TestLifecycle"))
+			}, component.WithName("TestLifecycle"))
 		})
 	})
 
 	t.Run("Spaces", func(t *testing.T) {
 		const name = "with spaces"
 		synctest.Test(t, func(t *testing.T) {
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				if l.Name() != name {
 					t.Errorf("L.Name() = %q, want %q", l.Name(), name)
 				}
-				l.Go(name, func(l *L) {
+				l.Go(name, func(l *component.L) {
 					const subname = "with spaces/with spaces"
 					if l.Name() != subname {
 						t.Errorf("L.Name() = %q, want %q", l.Name(), subname)
 					}
 				})
-			}, WithName(name))
+			}, component.WithName(name))
 		})
 	})
 
 	t.Run("Duplicate", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			RunProc(func(l *L) {
-				l.Go("dup", func(l *L) {
+			component.RunProc(func(l *component.L) {
+				l.Go("dup", func(l *component.L) {
 					if l.Name() != "/dup" {
 						t.Errorf("L.Name() = %q, want %q", l.Name(), "./dup")
 					}
 				})
-				l.Go("dup", func(l *L) {
+				l.Go("dup", func(l *component.L) {
 					if l.Name() != "/dup" {
 						t.Errorf("L.Name() = %q, want %q", l.Name(), "./dup")
 					}
 				})
-			}, WithName(""))
+			}, component.WithName(""))
 		})
 	})
 }
 
 func TestL_Terminate(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		RunProc(func(l *L) {
+		component.RunProc(func(l *component.L) {
 			l.Terminate()
 			if !errors.Is(l.Context().Err(), context.Canceled) {
 				t.Error("context should have been canceled")
 			}
-			if cause := context.Cause(l.Context()); !errors.Is(cause, ErrTerminated) {
-				t.Errorf("Cause() = %v, want %v", cause, ErrTerminated)
+			if cause := context.Cause(l.Context()); !errors.Is(cause, component.ErrTerminated) {
+				t.Errorf("Cause() = %v, want %v", cause, component.ErrTerminated)
 			}
-		}, WithName(t.Name()))
+		}, component.WithName(t.Name()))
 	})
 }
 
@@ -471,7 +473,7 @@ func TestL_Stop(t *testing.T) {
 			// in order to "ignore" the Stop() call,
 			// we must block RunProc() until Stop() returns
 			// although Stop() blocks, we block RunProc() until it returns
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				stopped := make(chan bool, 1) // buffered to avoid deadlock with the Stop() goroutine
 				go func() {
 					stopped <- l.Stop(180 * time.Millisecond)
@@ -480,7 +482,7 @@ func TestL_Stop(t *testing.T) {
 				if ok := <-stopped; ok {
 					t.Error("Stop() should have failed")
 				}
-			}, WithName(t.Name()))
+			}, component.WithName(t.Name()))
 		})
 	})
 
@@ -488,7 +490,7 @@ func TestL_Stop(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			stopped := make(chan bool, 1)
 			var signalled atomic.Bool // only used for logging
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				go func() {
 					// Stop() blocks, but we know it honors the given timeout
 					// because of the previous test ("Ignored")
@@ -498,7 +500,7 @@ func TestL_Stop(t *testing.T) {
 				// completes the lifecycle
 				<-l.Stopping()
 				signalled.Store(true)
-			}, WithName(t.Name()))
+			}, component.WithName(t.Name()))
 			if !<-stopped {
 				t.Logf("stop signal received = %v", signalled.Load())
 				t.Error("Stop() should have succeeded")
@@ -513,7 +515,7 @@ func TestL_Stop(t *testing.T) {
 		// because this guarantees that the lifecycle is not
 		// respecting its Stopped() signal.
 		synctest.Test(t, func(t *testing.T) {
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				stopped := make(chan bool, len(timeouts))
 				for i := range timeouts {
 					go func(timeout time.Duration) {
@@ -526,7 +528,7 @@ func TestL_Stop(t *testing.T) {
 						t.Errorf("Stop() should have failed (already stopped: %d/%d)", i, len(timeouts))
 					}
 				}
-			}, WithName(t.Name()))
+			}, component.WithName(t.Name()))
 		})
 	})
 
@@ -534,7 +536,7 @@ func TestL_Stop(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			stopped := make(chan bool)
 			ready := make(chan struct{})
-			RunProc(func(l *L) {
+			component.RunProc(func(l *component.L) {
 				go func() {
 					// stop parent-lifecycle immediately after the two
 					// child-lifecycles have been scheduled (by Go())
@@ -545,16 +547,16 @@ func TestL_Stop(t *testing.T) {
 					stopped <- l.Stop(time.Second)
 				}()
 
-				l.Go("child1", func(l *L) {
+				l.Go("child1", func(l *component.L) {
 					ready <- struct{}{}
 					<-l.Stopping() // wait for child-lifecycle to signal a stop
 				})
-				l.Go("child2", func(l *L) {
+				l.Go("child2", func(l *component.L) {
 					ready <- struct{}{}
 					<-l.Stopping() // wait for child-lifecycle to signal a stop
 				})
 				<-l.Stopping() // wait for parent-lifecycle to signal a stop
-			}, WithName(t.Name()))
+			}, component.WithName(t.Name()))
 			if !<-stopped {
 				t.Error("Stop() should have succeeded")
 			}
@@ -565,7 +567,7 @@ func TestL_Stop(t *testing.T) {
 func TestL_Continue(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		stopper := make(chan struct{})
-		RunProc(func(l *L) {
+		component.RunProc(func(l *component.L) {
 			if !l.Continue() {
 				t.Error("Continue() should have returned true")
 			}
@@ -578,6 +580,6 @@ func TestL_Continue(t *testing.T) {
 			if l.Continue() {
 				t.Error("Continue() should have returned false")
 			}
-		}, WithName(t.Name()), WithStopper(stopper))
+		}, component.WithName(t.Name()), component.WithStopper(stopper))
 	})
 }

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -464,12 +464,9 @@ func TestL_Terminate(t *testing.T) {
 }
 
 func TestL_Stop(t *testing.T) {
-	t.Parallel() // parallel because of a subtest which must time out to pass (also parallel)
-
 	// the following test verifies Stop() honors its timeout parameter
 	// (crucial for the next test to work)
 	t.Run("Ignored", func(t *testing.T) {
-		t.Parallel()
 		synctest.Test(t, func(t *testing.T) {
 			// in order to "ignore" the Stop() call,
 			// we must block RunProc() until Stop() returns
@@ -488,7 +485,6 @@ func TestL_Stop(t *testing.T) {
 	})
 
 	t.Run("Respected", func(t *testing.T) {
-		t.Parallel()
 		synctest.Test(t, func(t *testing.T) {
 			stopped := make(chan bool, 1)
 			var signalled atomic.Bool // only used for logging
@@ -511,7 +507,6 @@ func TestL_Stop(t *testing.T) {
 	})
 
 	t.Run("Concurrent", func(t *testing.T) {
-		t.Parallel()
 		// start multiple Stop() calls concurrently with different timeouts
 		timeouts := []time.Duration{18 * time.Millisecond, 36 * time.Millisecond, 180 * time.Millisecond}
 		// we do the actual testing within a call to RunProc()
@@ -536,7 +531,6 @@ func TestL_Stop(t *testing.T) {
 	})
 
 	t.Run("ChildLifecycle", func(t *testing.T) {
-		t.Parallel()
 		synctest.Test(t, func(t *testing.T) {
 			stopped := make(chan bool)
 			ready := make(chan struct{})

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -470,45 +470,49 @@ func TestL_Stop(t *testing.T) {
 	// (crucial for the next test to work)
 	t.Run("Ignored", func(t *testing.T) {
 		t.Parallel()
-		// in order to "ignore" the Stop() call,
-		// we must block RunProc() until Stop() returns
-		// although Stop() blocks, we block RunProc() until it returns
-		RunProc(func(l *L) {
-			stopped := make(chan bool, 1) // buffered to avoid deadlock with the Stop() goroutine
-			go func() {
-				stopped <- l.Stop(180 * time.Millisecond)
-			}()
-			// block the lifecycle until Stop() returns
-			select {
-			case ok := <-stopped:
-				if ok {
-					t.Error("Stop() should have failed")
+		synctest.Test(t, func(t *testing.T) {
+			// in order to "ignore" the Stop() call,
+			// we must block RunProc() until Stop() returns
+			// although Stop() blocks, we block RunProc() until it returns
+			RunProc(func(l *L) {
+				stopped := make(chan bool, 1) // buffered to avoid deadlock with the Stop() goroutine
+				go func() {
+					stopped <- l.Stop(180 * time.Millisecond)
+				}()
+				// block the lifecycle until Stop() returns
+				select {
+				case ok := <-stopped:
+					if ok {
+						t.Error("Stop() should have failed")
+					}
+				case <-time.After(SyncTimeout):
+					t.Error("timeout: Stop() should have returned by now")
 				}
-			case <-time.After(SyncTimeout):
-				t.Error("timeout: Stop() should have returned by now")
-			}
-		}, WithName(t.Name()))
+			}, WithName(t.Name()))
+		})
 	})
 
 	t.Run("Respected", func(t *testing.T) {
 		t.Parallel()
-		stopped := make(chan bool, 1)
-		var signalled atomic.Bool // only used for logging
-		RunProc(func(l *L) {
-			go func() {
-				// Stop() blocks, but we know it honors the given timeout
-				// because of the previous test ("Ignored")
-				stopped <- l.Stop(SyncTimeout)
-			}()
-			// returning after waiting for Stopping() to close
-			// completes the lifecycle
-			<-l.Stopping()
-			signalled.Store(true)
-		}, WithName(t.Name()))
-		if !<-stopped {
-			t.Logf("stop signal received = %v", signalled.Load())
-			t.Error("Stop() should have succeeded")
-		}
+		synctest.Test(t, func(t *testing.T) {
+			stopped := make(chan bool, 1)
+			var signalled atomic.Bool // only used for logging
+			RunProc(func(l *L) {
+				go func() {
+					// Stop() blocks, but we know it honors the given timeout
+					// because of the previous test ("Ignored")
+					stopped <- l.Stop(SyncTimeout)
+				}()
+				// returning after waiting for Stopping() to close
+				// completes the lifecycle
+				<-l.Stopping()
+				signalled.Store(true)
+			}, WithName(t.Name()))
+			if !<-stopped {
+				t.Logf("stop signal received = %v", signalled.Load())
+				t.Error("Stop() should have succeeded")
+			}
+		})
 	})
 
 	t.Run("Concurrent", func(t *testing.T) {
@@ -518,57 +522,61 @@ func TestL_Stop(t *testing.T) {
 		// we do the actual testing within a call to RunProc()
 		// because this guarantees that the lifecycle is not
 		// respecting its Stopped() signal.
-		RunProc(func(l *L) {
-			stopped := make(chan bool, len(timeouts))
-			for i := range timeouts {
-				go func(timeout time.Duration) {
-					stopped <- l.Stop(timeout)
-				}(timeouts[i])
-			}
-			// wait for all Stop() calls to return
-			timer := time.NewTimer(SyncTimeout)
-			defer timer.Stop()
-			for i := range timeouts {
-				select {
-				case ok := <-stopped:
-					if ok {
-						t.Errorf("Stop() should have failed (already stopped: %d/%d)", i, len(timeouts))
-					}
-				case <-timer.C:
-					t.Fatal("timeout: Stop() did not return")
+		synctest.Test(t, func(t *testing.T) {
+			RunProc(func(l *L) {
+				stopped := make(chan bool, len(timeouts))
+				for i := range timeouts {
+					go func(timeout time.Duration) {
+						stopped <- l.Stop(timeout)
+					}(timeouts[i])
 				}
-			}
-		}, WithName(t.Name()))
+				// wait for all Stop() calls to return
+				timer := time.NewTimer(SyncTimeout)
+				defer timer.Stop()
+				for i := range timeouts {
+					select {
+					case ok := <-stopped:
+						if ok {
+							t.Errorf("Stop() should have failed (already stopped: %d/%d)", i, len(timeouts))
+						}
+					case <-timer.C:
+						t.Fatal("timeout: Stop() did not return")
+					}
+				}
+			}, WithName(t.Name()))
+		})
 	})
 
 	t.Run("ChildLifecycle", func(t *testing.T) {
 		t.Parallel()
-		stopped := make(chan bool)
-		ready := make(chan struct{})
-		RunProc(func(l *L) {
-			go func() {
-				// stop parent-lifecycle immediately after the two
-				// child-lifecycles have been scheduled (by Go())
-				// because starting them after initiating the stop
-				// causes a panic.
-				<-ready
-				<-ready
-				stopped <- l.Stop(time.Second)
-			}()
+		synctest.Test(t, func(t *testing.T) {
+			stopped := make(chan bool)
+			ready := make(chan struct{})
+			RunProc(func(l *L) {
+				go func() {
+					// stop parent-lifecycle immediately after the two
+					// child-lifecycles have been scheduled (by Go())
+					// because starting them after initiating the stop
+					// causes a panic.
+					<-ready
+					<-ready
+					stopped <- l.Stop(time.Second)
+				}()
 
-			l.Go("child1", func(l *L) {
-				ready <- struct{}{}
-				<-l.Stopping() // wait for child-lifecycle to signal a stop
-			})
-			l.Go("child2", func(l *L) {
-				ready <- struct{}{}
-				<-l.Stopping() // wait for child-lifecycle to signal a stop
-			})
-			<-l.Stopping() // wait for parent-lifecycle to signal a stop
-		}, WithName(t.Name()))
-		if !<-stopped {
-			t.Error("Stop() should have succeeded")
-		}
+				l.Go("child1", func(l *L) {
+					ready <- struct{}{}
+					<-l.Stopping() // wait for child-lifecycle to signal a stop
+				})
+				l.Go("child2", func(l *L) {
+					ready <- struct{}{}
+					<-l.Stopping() // wait for child-lifecycle to signal a stop
+				})
+				<-l.Stopping() // wait for parent-lifecycle to signal a stop
+			}, WithName(t.Name()))
+			if !<-stopped {
+				t.Error("Stop() should have succeeded")
+			}
+		})
 	})
 }
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -52,17 +53,19 @@ func TestDrivenDevelopment(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				var called bool
-				RunProc(func(l *L) {
-					tt.fn(l)
-					called = true
-				}, WithName(t.Name()))
-				if tt.wantAbort && called {
-					t.Error("execution should have been aborted")
-				}
-				if !tt.wantAbort && !called {
-					t.Error("execution should not have been aborted")
-				}
+				synctest.Test(t, func(t *testing.T) {
+					var called bool
+					RunProc(func(l *L) {
+						tt.fn(l)
+						called = true
+					}, WithName(t.Name()))
+					if tt.wantAbort && called {
+						t.Error("execution should have been aborted")
+					}
+					if !tt.wantAbort && !called {
+						t.Error("execution should not have been aborted")
+					}
+				})
 			})
 		}
 	})

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -346,38 +346,44 @@ func TestL_Fatal(t *testing.T) {
 
 func TestL_Context(t *testing.T) {
 	t.Run("Background", func(t *testing.T) {
-		RunProc(func(l *L) {
-			_, ok := l.Context().Deadline()
-			if ok {
-				t.Error("context should not have a deadline")
-			}
-		}, WithName(t.Name()))
+		synctest.Test(t, func(t *testing.T) {
+			RunProc(func(l *L) {
+				_, ok := l.Context().Deadline()
+				if ok {
+					t.Error("context should not have a deadline")
+				}
+			}, WithName(t.Name()))
+		})
 	})
 	t.Run("Canceled", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		RunProc(func(l *L) {
-			if !errors.Is(l.Context().Err(), context.Canceled) {
-				t.Error("context should have been canceled")
-			}
-		}, WithName(t.Name()), WithContext(ctx))
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			RunProc(func(l *L) {
+				if !errors.Is(l.Context().Err(), context.Canceled) {
+					t.Error("context should have been canceled")
+				}
+			}, WithName(t.Name()), WithContext(ctx))
+		})
 	})
 	t.Run("DeadlineExceeded", func(t *testing.T) {
 		t.Parallel()
-		const timeout = time.Millisecond
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		RunProc(func(l *L) {
-			// wait for context to expire
-			select {
-			case <-l.Context().Done():
-				if !errors.Is(l.Context().Err(), context.DeadlineExceeded) {
-					t.Error("context deadline should have been exceeded")
+		synctest.Test(t, func(t *testing.T) {
+			const timeout = time.Millisecond
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			RunProc(func(l *L) {
+				// wait for context to expire
+				select {
+				case <-l.Context().Done():
+					if !errors.Is(l.Context().Err(), context.DeadlineExceeded) {
+						t.Error("context deadline should have been exceeded")
+					}
+				case <-time.After(SyncTimeout):
+					t.Error("timeout: context should have been canceled by now")
 				}
-			case <-time.After(SyncTimeout):
-				t.Error("timeout: context should have been canceled by now")
-			}
-		}, WithName(t.Name()), WithContext(ctx))
+			}, WithName(t.Name()), WithContext(ctx))
+		})
 	})
 }
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -384,60 +384,68 @@ func TestL_Context(t *testing.T) {
 
 func TestL_Name(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
-		RunProc(func(l *L) {
-			if l.Name() != "" {
-				t.Errorf("parent Name() = %q, want %q", l.Name(), "")
-			}
-			// see child initialization for why this is "/"
-			l.Go("", func(l *L) {
-				if l.Name() != "/" {
-					t.Errorf("child Name() = %q, want %q", l.Name(), "./")
+		synctest.Test(t, func(t *testing.T) {
+			RunProc(func(l *L) {
+				if l.Name() != "" {
+					t.Errorf("parent Name() = %q, want %q", l.Name(), "")
 				}
-			})
-		}, WithName(""))
+				// see child initialization for why this is "/"
+				l.Go("", func(l *L) {
+					if l.Name() != "/" {
+						t.Errorf("child Name() = %q, want %q", l.Name(), "./")
+					}
+				})
+			}, WithName(""))
+		})
 	})
 
 	t.Run("Sanity", func(t *testing.T) {
-		RunProc(func(l *L) {
-			if l.Name() != "TestLifecycle" {
-				t.Errorf("Name() = %q, want %q", l.Name(), "TestLifecycle")
-			}
-			l.Go("Child", func(l *L) {
-				if l.Name() != "TestLifecycle/Child" {
-					t.Errorf("Name() = %q, want %q", l.Name(), "TestLifecycle/Child")
+		synctest.Test(t, func(t *testing.T) {
+			RunProc(func(l *L) {
+				if l.Name() != "TestLifecycle" {
+					t.Errorf("Name() = %q, want %q", l.Name(), "TestLifecycle")
 				}
-			})
-		}, WithName("TestLifecycle"))
+				l.Go("Child", func(l *L) {
+					if l.Name() != "TestLifecycle/Child" {
+						t.Errorf("Name() = %q, want %q", l.Name(), "TestLifecycle/Child")
+					}
+				})
+			}, WithName("TestLifecycle"))
+		})
 	})
 
 	t.Run("Spaces", func(t *testing.T) {
 		const name = "with spaces"
-		RunProc(func(l *L) {
-			if l.Name() != name {
-				t.Errorf("L.Name() = %q, want %q", l.Name(), name)
-			}
-			l.Go(name, func(l *L) {
-				const subname = "with spaces/with spaces"
-				if l.Name() != subname {
-					t.Errorf("L.Name() = %q, want %q", l.Name(), subname)
+		synctest.Test(t, func(t *testing.T) {
+			RunProc(func(l *L) {
+				if l.Name() != name {
+					t.Errorf("L.Name() = %q, want %q", l.Name(), name)
 				}
-			})
-		}, WithName(name))
+				l.Go(name, func(l *L) {
+					const subname = "with spaces/with spaces"
+					if l.Name() != subname {
+						t.Errorf("L.Name() = %q, want %q", l.Name(), subname)
+					}
+				})
+			}, WithName(name))
+		})
 	})
 
 	t.Run("Duplicate", func(t *testing.T) {
-		RunProc(func(l *L) {
-			l.Go("dup", func(l *L) {
-				if l.Name() != "/dup" {
-					t.Errorf("L.Name() = %q, want %q", l.Name(), "./dup")
-				}
-			})
-			l.Go("dup", func(l *L) {
-				if l.Name() != "/dup" {
-					t.Errorf("L.Name() = %q, want %q", l.Name(), "./dup")
-				}
-			})
-		}, WithName(""))
+		synctest.Test(t, func(t *testing.T) {
+			RunProc(func(l *L) {
+				l.Go("dup", func(l *L) {
+					if l.Name() != "/dup" {
+						t.Errorf("L.Name() = %q, want %q", l.Name(), "./dup")
+					}
+				})
+				l.Go("dup", func(l *L) {
+					if l.Name() != "/dup" {
+						t.Errorf("L.Name() = %q, want %q", l.Name(), "./dup")
+					}
+				})
+			}, WithName(""))
+		})
 	})
 }
 

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -186,58 +186,64 @@ func TestL_Cleanup(t *testing.T) {
 
 func TestL_Fatal(t *testing.T) {
 	t.Run("CalledFromNestedFunctions", func(t *testing.T) {
-		RunProc(func(l *L) {
-			func() {
+		synctest.Test(t, func(t *testing.T) {
+			RunProc(func(l *L) {
 				func() {
 					func() {
-						l.Fatal(fmt.Errorf("test error"))
-						t.Fatal("L.Fatal() should have aborted execution (nesting level 0)")
+						func() {
+							l.Fatal(fmt.Errorf("test error"))
+							t.Fatal("L.Fatal() should have aborted execution (nesting level 0)")
+						}()
+						t.Error("L.Fatal() should have aborted execution (nesting level -1)")
 					}()
-					t.Error("L.Fatal() should have aborted execution (nesting level -1)")
+					t.Error("L.Fatal() should have aborted execution (nesting level -2)")
 				}()
-				t.Error("L.Fatal() should have aborted execution (nesting level -2)")
-			}()
-			t.Error("L.Fatal() should have aborted execution (nesting level -3)")
-		}, WithName(t.Name()))
+				t.Error("L.Fatal() should have aborted execution (nesting level -3)")
+			}, WithName(t.Name()))
+		})
 	})
 
 	t.Run("CalledFromMultipleGoroutines", func(t *testing.T) {
 		for _, goroutines := range []int{1, 2, 16} {
 			t.Run(fmt.Sprintf("ConcurrentCalls=%d", goroutines), func(t *testing.T) {
-				RunProc(func(l *L) {
-					done := make(chan struct{})
-					for i := range goroutines {
-						go func(index int) {
-							defer func() { done <- struct{}{} }()
-							l.Fatal(fmt.Errorf("test error from goroutine #%d", index))
-							t.Errorf("goroutine #%d: L.Fatal() should have aborted execution", index)
-						}(i)
-					}
-					// pay attention to the fact that we're still in the primary goroutine
-					// of the lifecycle - calls to L.Fatal from other goroutines do not
-					// (and cannot) affect the primary goroutine.
-					for range goroutines {
-						select {
-						case <-done:
-						case <-time.After(SyncTimeout):
-							t.Fatal("timeout: L.Fatal() did not call deferred functions in goroutines")
+				synctest.Test(t, func(t *testing.T) {
+					RunProc(func(l *L) {
+						done := make(chan struct{})
+						for i := range goroutines {
+							go func(index int) {
+								defer func() { done <- struct{}{} }()
+								l.Fatal(fmt.Errorf("test error from goroutine #%d", index))
+								t.Errorf("goroutine #%d: L.Fatal() should have aborted execution", index)
+							}(i)
 						}
-					}
-				}, WithName(t.Name()))
+						// pay attention to the fact that we're still in the primary goroutine
+						// of the lifecycle - calls to L.Fatal from other goroutines do not
+						// (and cannot) affect the primary goroutine.
+						for range goroutines {
+							select {
+							case <-done:
+							case <-time.After(SyncTimeout):
+								t.Fatal("timeout: L.Fatal() did not call deferred functions in goroutines")
+							}
+						}
+					}, WithName(t.Name()))
+				})
 			})
 		}
 	})
 
 	t.Run("CallsCleanupFunctions", func(t *testing.T) {
-		var called bool
-		RunProc(func(l *L) {
-			l.Cleanup(func() { called = true })
-			l.Fatal(fmt.Errorf("test error"))
-			t.Error("L.Fatal() should have aborted execution")
-		}, WithName(t.Name()))
-		if !called {
-			t.Error("Cleanup() function should have been called")
-		}
+		synctest.Test(t, func(t *testing.T) {
+			var called bool
+			RunProc(func(l *L) {
+				l.Cleanup(func() { called = true })
+				l.Fatal(fmt.Errorf("test error"))
+				t.Error("L.Fatal() should have aborted execution")
+			}, WithName(t.Name()))
+			if !called {
+				t.Error("Cleanup() function should have been called")
+			}
+		})
 	})
 
 	t.Run("CalledFromCleanupFunction", func(t *testing.T) {
@@ -246,22 +252,24 @@ func TestL_Fatal(t *testing.T) {
 		// Cleanup() function, we test the other side of the coin as well
 		// to ensure this test does not pass by accident due to human error.
 		var calledBeforeFatal, calledAfterFatal bool
-		RunProc(func(l *L) {
-			l.Cleanup(func() {
-				// scheduled before Fatal(), but executed after because
-				// cleanup functions are executed in reverse order
-				calledAfterFatal = true
-			})
-			l.Cleanup(func() {
-				l.Fatal(fmt.Errorf("test error"))
-				t.Error("L.Fatal() should have aborted execution of this Cleanup() function")
-			})
-			l.Cleanup(func() {
-				// scheduled after Fatal(), but executed before because
-				// cleanup functions are executed in reverse order
-				calledBeforeFatal = true
-			})
-		}, WithName(t.Name()))
+		synctest.Test(t, func(t *testing.T) {
+			RunProc(func(l *L) {
+				l.Cleanup(func() {
+					// scheduled before Fatal(), but executed after because
+					// cleanup functions are executed in reverse order
+					calledAfterFatal = true
+				})
+				l.Cleanup(func() {
+					l.Fatal(fmt.Errorf("test error"))
+					t.Error("L.Fatal() should have aborted execution of this Cleanup() function")
+				})
+				l.Cleanup(func() {
+					// scheduled after Fatal(), but executed before because
+					// cleanup functions are executed in reverse order
+					calledBeforeFatal = true
+				})
+			}, WithName(t.Name()))
+		})
 		if !calledBeforeFatal {
 			t.Error("Cleanup() function should have been called before L.Fatal()")
 		}
@@ -304,35 +312,39 @@ func TestL_Fatal(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				RunProc(func(l *L) {
-					l.Cleanup(func() {
-						if !errors.Is(l.Context().Err(), context.Canceled) {
-							t.Error("context should have been canceled")
-						}
-						if cause := context.Cause(l.Context()); !errors.Is(cause, sentinel) {
-							t.Logf("context error: %q", cause)
-							t.Error("context should have been canceled with the sentinel error")
-						}
-					})
-					tt.fn(l)
-				}, WithName(t.Name()))
+				synctest.Test(t, func(t *testing.T) {
+					RunProc(func(l *L) {
+						l.Cleanup(func() {
+							if !errors.Is(l.Context().Err(), context.Canceled) {
+								t.Error("context should have been canceled")
+							}
+							if cause := context.Cause(l.Context()); !errors.Is(cause, sentinel) {
+								t.Logf("context error: %q", cause)
+								t.Error("context should have been canceled with the sentinel error")
+							}
+						})
+						tt.fn(l)
+					}, WithName(t.Name()))
+				})
 			})
 		}
 	})
 
 	t.Run("CalledAfterCompletion", func(t *testing.T) {
-		// capture l variable to simulate a closure over it
-		// (may happen in real code when storing a reference to
-		// the lifecycle)
-		var capture *L
-		RunProc(func(l *L) { capture = l }, WithName(t.Name()))
-		// calling L.Fatal after the lifecycle has completed should panic
-		defer func() {
-			if reason := recover(); reason == nil {
-				t.Error("L.Fatal() must panic if called after component completion")
-			}
-		}()
-		capture.Fatal(fmt.Errorf("test error"))
+		synctest.Test(t, func(t *testing.T) {
+			// capture l variable to simulate a closure over it
+			// (may happen in real code when storing a reference to
+			// the lifecycle)
+			var capture *L
+			RunProc(func(l *L) { capture = l }, WithName(t.Name()))
+			// calling L.Fatal after the lifecycle has completed should panic
+			defer func() {
+				if reason := recover(); reason == nil {
+					t.Error("L.Fatal() must panic if called after component completion")
+				}
+			}()
+			capture.Fatal(fmt.Errorf("test error"))
+		})
 	})
 }
 


### PR DESCRIPTION
The lifecycle suite synchronised its concurrent scenarios with sleep-based timeouts and a `SyncTimeout` constant — brittle, timing-dependent, and slow, since every "this must not happen yet" assertion paid real wall-clock time to prove a negative. This migrates the suite to `testing/synctest`, whose per-bubble fake clock advances only once every goroutine is durably blocked, giving deterministic control over the startup, shutdown, and cleanup sequencing the framework's concurrency depends on.

The work proceeds conservatively, one top-level test at a time: each test is first wrapped in a `synctest.Test` bubble with its assertions left exactly as they were, and only then is the now-redundant machinery peeled away. Inside a bubble a stalled goroutine surfaces as a deadlock report instead of a silent hang, so the `time.After(SyncTimeout)` and `time.NewTimer` guard rails that once protected those waits become dead branches and are dropped. The `t.Parallel()` calls existed only to keep the real-clock timeouts off the critical path; under the fake clock those waits are instant, so the parallelism goes too. Channels, timers, and contexts that drive a test's timing are constructed inside the bubble so they belong to its clock. The commit history is grouped per top-level test — bubble commit first, then that test's modernization commits — so each test's evolution reads top to bottom.

Finally the suite moves to `package component_test`. It had already stopped referencing any unexported symbol, so binding it to the exported API (`RunProc`, `L`, the `With*` options, `ErrTerminated`) keeps the black-box contract honest and stops future tests from quietly reaching into internals.

Scope and exclusions: the change is confined to `lifecycle_test.go`, the only suite that relied on sleep/timeout-based concurrency synchronisation; the other root tests and the subpackage tests do not exercise lifecycle concurrency and are left untouched. `SyncTimeout` is gone entirely — with every wall-clock guard rail removed, its last reference (the timeout argument to `l.Stop()` in `TestL_Stop/Respected`) became a plain `time.Second` literal whose only job is to be comfortably longer than the now-instant stop. Documenting reusable synctest patterns for component authors is deliberately deferred to a follow-up; this PR establishes the pattern in the suite itself. No production code changes.

Verification: `go test -race ./...` passes and is deterministic across 20 repeated runs, `golangci-lint run ./...` reports no issues, and every commit compiles its tests independently.

Addresses #10.
