### PR TITLE
Enable the notorious-ai github-author and golang-dev plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,8 @@
         "repo": "notorious-ai/claude-plugins"
       }
     }
+  },
+  "enabledPlugins": {
+    "github-author@notorious-ai": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "extraKnownMarketplaces": {
+    "notorious-ai": {
+      "source": {
+        "source": "github",
+        "repo": "notorious-ai/claude-plugins"
+      }
+    }
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,7 @@
     }
   },
   "enabledPlugins": {
-    "github-author@notorious-ai": true
+    "github-author@notorious-ai": true,
+    "golang-dev@notorious-ai": true
   }
 }


### PR DESCRIPTION
The github-author and golang-dev plugins from the notorious-ai marketplace encode the conventions this repository already follows by hand: imperative PR titles with repository-capability verbs, Go-team commit targeting, and idiomatic Go naming. Until now each contributor had to register the marketplace and enable these plugins in their own local settings, so nothing made them part of the project. Checking the configuration into the tracked `.claude/settings.json` makes both plugins active for anyone who opens the repository in Claude Code.

The change lands as three atomic commits — registering the marketplace, then enabling each plugin — so the marketplace source can be reviewed and bisected independently of the plugins that depend on it. Only `.claude/settings.json` is committed; `.claude/settings.local.json` stays out of version control via the global gitignore, so personal overrides remain local.

No issue tracks this, as it is tooling configuration rather than a change to the module's behavior.