### PR TITLE
Simplify TestL_Stop scaffolding and correct TestL_Name failure messages

### DIFF
--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -466,16 +466,13 @@ func TestL_Stop(t *testing.T) {
 	// (crucial for the next test to work)
 	t.Run("Ignored", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			// in order to "ignore" the Stop() call,
-			// we must block RunProc() until Stop() returns
-			// although Stop() blocks, we block RunProc() until it returns
 			component.RunProc(func(l *component.L) {
-				stopped := make(chan bool, 1) // buffered to avoid deadlock with the Stop() goroutine
-				go func() {
-					stopped <- l.Stop(180 * time.Millisecond)
-				}()
-				// block the lifecycle until Stop() returns
-				if ok := <-stopped; ok {
+				// Calling Stop() from the lifecycle's own goroutine parks it
+				// here: the lifecycle cannot complete while it waits inside
+				// Stop(), so Stop() can only return by hitting its deadline -
+				// which the fake clock reaches the instant every goroutine is
+				// durably blocked.
+				if l.Stop(180 * time.Millisecond) {
 					t.Error("Stop() should have failed")
 				}
 			}, component.WithName(t.Name()))

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -390,7 +390,7 @@ func TestL_Name(t *testing.T) {
 				// see child initialization for why this is "/"
 				l.Go("", func(l *component.L) {
 					if l.Name() != "/" {
-						t.Errorf("child Name() = %q, want %q", l.Name(), "./")
+						t.Errorf("child Name() = %q, want %q", l.Name(), "/")
 					}
 				})
 			}, component.WithName(""))
@@ -434,12 +434,12 @@ func TestL_Name(t *testing.T) {
 			component.RunProc(func(l *component.L) {
 				l.Go("dup", func(l *component.L) {
 					if l.Name() != "/dup" {
-						t.Errorf("L.Name() = %q, want %q", l.Name(), "./dup")
+						t.Errorf("L.Name() = %q, want %q", l.Name(), "/dup")
 					}
 				})
 				l.Go("dup", func(l *component.L) {
 					if l.Name() != "/dup" {
-						t.Errorf("L.Name() = %q, want %q", l.Name(), "./dup")
+						t.Errorf("L.Name() = %q, want %q", l.Name(), "/dup")
 					}
 				})
 			}, component.WithName(""))

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -481,21 +481,21 @@ func TestL_Stop(t *testing.T) {
 
 	t.Run("Respected", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			stopped := make(chan bool, 1)
-			var signalled atomic.Bool // only used for logging
+			// Stop() must run in a goroutine other than the one that completes
+			// the lifecycle, since it blocks until the primary goroutine returns
+			// from Stopping(). The channel carries the verdict back out with the
+			// happens-before the assertion needs: a plain shared bool could be
+			// read before the Stop() goroutine is joined at the end of the bubble.
+			stopped := make(chan bool)
 			component.RunProc(func(l *component.L) {
 				go func() {
-					// Stop() blocks, but we know it honors the given timeout
-					// because of the previous test ("Ignored")
+					// Stop() honors its timeout - see the "Ignored" subtest -
+					// so a success here means the lifecycle reacted in time.
 					stopped <- l.Stop(time.Second)
 				}()
-				// returning after waiting for Stopping() to close
-				// completes the lifecycle
-				<-l.Stopping()
-				signalled.Store(true)
+				<-l.Stopping() // react to the stop, then return to complete
 			}, component.WithName(t.Name()))
 			if !<-stopped {
-				t.Logf("stop signal received = %v", signalled.Load())
 				t.Error("Stop() should have succeeded")
 			}
 		})


### PR DESCRIPTION
Three test-only follow-ups to #65 that missed the merge. Now that the lifecycle suite runs under synctest, `TestL_Stop/Ignored` can call `Stop()` directly from the lifecycle goroutine instead of offloading it over a channel, and `TestL_Stop/Respected` no longer needs its logging-only atomic. Separately, `TestL_Name`'s failure messages printed the wrong expected value (`"./"` where the code asserts `"/"`), so a real regression would have misdirected the reader; this aligns them. No production changes.